### PR TITLE
Remove overhead

### DIFF
--- a/.github/workflows/adopt-ruff.yml
+++ b/.github/workflows/adopt-ruff.yml
@@ -1,5 +1,5 @@
 name: Adopt Ruff
-on: [push, workflow_dispatch]
+on: [push, workflow_dispatch, pull_request]
 
 jobs:
   adopt-ruff:
@@ -7,6 +7,16 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
+      
+      - name: Install ruff
+        run: pip install ruff
+        shell: bash
+
+      - name: Set up python
+        id: setup-python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
 
       - name: Run the adopt-ruff action
         uses: ./

--- a/.github/workflows/adopt-ruff.yml
+++ b/.github/workflows/adopt-ruff.yml
@@ -1,5 +1,5 @@
 name: Adopt Ruff
-on: [push, workflow_dispatch, pull_request]
+on: [workflow_dispatch, pull_request]
 
 jobs:
   adopt-ruff:

--- a/.github/workflows/adopt-ruff.yml
+++ b/.github/workflows/adopt-ruff.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Run the adopt-ruff action
         uses: ./
         with:
-          version: foo
+          version: ${{  github.ref  }}

--- a/.github/workflows/adopt-ruff.yml
+++ b/.github/workflows/adopt-ruff.yml
@@ -20,3 +20,5 @@ jobs:
 
       - name: Run the adopt-ruff action
         uses: ./
+        with:
+          version: foo

--- a/.github/workflows/adopt-ruff.yml
+++ b/.github/workflows/adopt-ruff.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Run the adopt-ruff action
         uses: ./
         with:
-          version: ${{  github.ref  }}
+          version: ${{  github.ref_name  }}

--- a/.github/workflows/adopt-ruff.yml
+++ b/.github/workflows/adopt-ruff.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Run the adopt-ruff action
         uses: ./
         with:
-          version: ${{  github.ref_name  }}
+          version: ${{  github.sha  }}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Current File",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "cwd": "${workspaceFolder}",
+            "console": "integratedTerminal",
+            "justMyCode": true
+        }
+    ]
+}

--- a/action.yml
+++ b/action.yml
@@ -9,18 +9,8 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Set up python
-      id: setup-python
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.11"
-
     - name: Install adopt-ruff
       run: pip install git+https://github.com/ScDor/adopt-ruff -q
-      shell: bash
-
-    - name: Install ruff
-      run: pip install ruff # TODO
       shell: bash
 
     - name: Run adopt-ruff

--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ runs:
       shell: bash
 
     - name: Run adopt-ruff
-      run: python -m adopt_ruff
+      run: adopt_ruff
       shell: bash
 
     - name: Set step summary

--- a/action.yml
+++ b/action.yml
@@ -15,39 +15,23 @@ runs:
       with:
         python-version: "3.11"
 
-    - name: Set up Poetry
-      uses: snok/install-poetry@v1
-      with:
-        virtualenvs-create: true
-        virtualenvs-in-project: true
-        installer-parallel: true
-
-    - name: Load cached venv
-      id: cached-poetry-dependencies
-      uses: actions/cache@v3
-      with:
-        path: .venv
-        key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
-
-    - name: Install dependencies
-      if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-      run: poetry install --no-interaction --no-root
+    - name: Install adopt-ruff
+      run: pip install git+https://github.com/ScDor/adopt-ruff
       shell: bash
 
-    - name: Parse Ruff rules
+    - name: Install ruff
+      run: pip install ruff # TODO
+      shell: bash
+
+    - name: Parse ruff rules
       id: ruff_rules
       run: poetry run ruff rule --all --output-format=json > rules.json
       shell: bash
 
-    - name: Parse Ruff violations
+    - name: Parse ruff violations
       id: ruff_output
       run: poetry run ruff . --output-format=json --select=ALL --exit-zero > violations.json
       shell: bash
-
-    - name: Validate json files
-      uses: GrantBirki/json-yaml-validate@v2.6.0
-      with:
-        files: "violations.json, rules.json"
 
     - name: Run adopt-ruff
       run: poetry run adopt_ruff

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ runs:
         python-version: "3.11"
 
     - name: Install adopt-ruff
-      run: pip install git+https://github.com/ScDor/adopt-ruff@remove-poetry-install # TODO
+      run: pip install git+https://github.com/ScDor/adopt-ruff@remove-poetry-install -q # TODO
       shell: bash
 
     - name: Install ruff

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ runs:
         python-version: "3.11"
 
     - name: Install adopt-ruff
-      run: pip install git+https://github.com/ScDor/adopt-ruff@remove-poetry-install -q # TODO
+      run: pip install git+https://github.com/ScDor/adopt-ruff -q
       shell: bash
 
     - name: Install ruff

--- a/action.yml
+++ b/action.yml
@@ -2,15 +2,15 @@ name: "adopt-ruff"
 
 description: "Adopt ruff easily"
 inputs:
-  repository:
-    description: "Repository name with owner. For example, ScDor/adopt-ruff"
-    default: ${{ github.repository }}
+  version:
+    description: "version"
+    default: master
 
 runs:
   using: "composite"
   steps:
     - name: Install adopt-ruff
-      run: pip install git+https://github.com/ScDor/adopt-ruff -q
+      run: pip install git+https://github.com/ScDor/adopt-ruff${{  inputs.version  }} -q
       shell: bash
 
     - name: Run adopt-ruff

--- a/action.yml
+++ b/action.yml
@@ -23,16 +23,6 @@ runs:
       run: pip install ruff # TODO
       shell: bash
 
-    - name: Parse ruff rules
-      id: ruff_rules
-      run: python -m ruff rule --all --output-format=json > rules.json
-      shell: bash
-
-    - name: Parse ruff violations
-      id: ruff_output
-      run: python -m  ruff . --output-format=json --select=ALL --exit-zero > violations.json
-      shell: bash
-
     - name: Run adopt-ruff
       run: adopt_ruff
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -25,16 +25,16 @@ runs:
 
     - name: Parse ruff rules
       id: ruff_rules
-      run: poetry run ruff rule --all --output-format=json > rules.json
+      run: python -m ruff rule --all --output-format=json > rules.json
       shell: bash
 
     - name: Parse ruff violations
       id: ruff_output
-      run: poetry run ruff . --output-format=json --select=ALL --exit-zero > violations.json
+      run: python -m  ruff . --output-format=json --select=ALL --exit-zero > violations.json
       shell: bash
 
     - name: Run adopt-ruff
-      run: poetry run adopt_ruff
+      run: python adopt_ruff
       shell: bash
 
     - name: Set step summary

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ runs:
       shell: bash
 
     - name: Run adopt-ruff
-      run: adopt_ruff
+      run: adopt-ruff
       shell: bash
 
     - name: Set step summary

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ runs:
         python-version: "3.11"
 
     - name: Install adopt-ruff
-      run: pip install git+https://github.com/ScDor/adopt-ruff
+      run: pip install git+https://github.com/ScDor/adopt-ruff@remove-poetry-install # TODO
       shell: bash
 
     - name: Install ruff

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ runs:
   using: "composite"
   steps:
     - name: Install adopt-ruff
-      run: pip install git+https://github.com/ScDor/adopt-ruff${{  inputs.version  }} -q
+      run: pip install git+https://github.com/ScDor/adopt-ruff@${{  inputs.version  }} -q
       shell: bash
 
     - name: Run adopt-ruff

--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ runs:
       shell: bash
 
     - name: Run adopt-ruff
-      run: python adopt_ruff
+      run: python -m adopt_ruff
       shell: bash
 
     - name: Set step summary

--- a/poetry.lock
+++ b/poetry.lock
@@ -331,7 +331,7 @@ files = [
 name = "ruff"
 version = "0.1.11"
 description = "An extremely fast Python linter and code formatter, written in Rust."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -422,4 +422,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "8a97c592b37725b120b68aa09b0cbb447a0a8ec484e4b5b051ed7d34be8debcb"
+content-hash = "51d111183df1c1a7e5804c03c7eb5a7f7326b5f761abae6ba7700f410aee0a47"

--- a/poetry.lock
+++ b/poetry.lock
@@ -126,6 +126,18 @@ files = [
 setuptools = "*"
 
 [[package]]
+name = "packaging"
+version = "23.2"
+description = "Core utilities for Python packages"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "packaging-23.2-py3-none-any.whl", hash = "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7"},
+    {file = "packaging-23.2.tar.gz", hash = "sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5"},
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.1.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
@@ -468,4 +480,4 @@ dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "e8a9749a37a9b445735605f586e98a200f5ee739c92a7fd68b54d5d47a94e94e"
+content-hash = "ffe7b563b4b722357606e5aaa41f5a15b809217f8c21c85d93cc6c93284fdf8d"

--- a/poetry.lock
+++ b/poetry.lock
@@ -25,6 +25,18 @@ files = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+description = "Cross-platform colored terminal text."
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
+files = [
+    {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
+    {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
+]
+
+[[package]]
 name = "distlib"
 version = "0.3.8"
 description = "Distribution utilities"
@@ -67,6 +79,25 @@ files = [
 
 [package.extras]
 license = ["ukkonen"]
+
+[[package]]
+name = "loguru"
+version = "0.7.2"
+description = "Python logging made (stupidly) simple"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "loguru-0.7.2-py3-none-any.whl", hash = "sha256:003d71e3d3ed35f0f8984898359d65b79e5b21943f78af86aa5491210429b8eb"},
+    {file = "loguru-0.7.2.tar.gz", hash = "sha256:e671a53522515f34fd406340ee968cb9ecafbc4b36c679da03c18fd8d0bd51ac"},
+]
+
+[package.dependencies]
+colorama = {version = ">=0.3.4", markers = "sys_platform == \"win32\""}
+win32-setctime = {version = ">=1.0.0", markers = "sys_platform == \"win32\""}
+
+[package.extras]
+dev = ["Sphinx (==7.2.5)", "colorama (==0.4.5)", "colorama (==0.4.6)", "exceptiongroup (==1.1.3)", "freezegun (==1.1.0)", "freezegun (==1.2.2)", "mypy (==v0.910)", "mypy (==v0.971)", "mypy (==v1.4.1)", "mypy (==v1.5.1)", "pre-commit (==3.4.0)", "pytest (==6.1.2)", "pytest (==7.4.0)", "pytest-cov (==2.12.1)", "pytest-cov (==4.1.0)", "pytest-mypy-plugins (==1.9.3)", "pytest-mypy-plugins (==3.0.0)", "sphinx-autobuild (==2021.3.14)", "sphinx-rtd-theme (==1.3.0)", "tox (==3.27.1)", "tox (==4.11.0)"]
 
 [[package]]
 name = "mdutils"
@@ -419,7 +450,22 @@ platformdirs = ">=3.9.1,<5"
 docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.2)", "sphinx-argparse (>=0.4)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=23.6)"]
 test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.4)", "pytest-env (>=0.8.2)", "pytest-freezer (>=0.4.8)", "pytest-mock (>=3.11.1)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=68)", "time-machine (>=2.10)"]
 
+[[package]]
+name = "win32-setctime"
+version = "1.1.0"
+description = "A small Python utility to set file creation time on Windows"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "win32_setctime-1.1.0-py3-none-any.whl", hash = "sha256:231db239e959c2fe7eb1d7dc129f11172354f98361c4fa2d6d2d7e278baa8aad"},
+    {file = "win32_setctime-1.1.0.tar.gz", hash = "sha256:15cf5750465118d6929ae4de4eb46e8edae9a5634350c01ba582df868e932cb2"},
+]
+
+[package.extras]
+dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
+
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "51d111183df1c1a7e5804c03c7eb5a7f7326b5f761abae6ba7700f410aee0a47"
+content-hash = "e8a9749a37a9b445735605f586e98a200f5ee739c92a7fd68b54d5d47a94e94e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ pre-commit = "^3.6.0"
 ruff = "^0.1.11"
 
 [tool.poetry.scripts]
-adopt-ruff = "adopt_ruff.adopt_ruff:main"
+adopt-ruff = "adopt_ruff.main:main"
 
 [tool.ruff]
 target-version = "py311"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ pre-commit = "^3.6.0"
 ruff = "^0.1.11"
 
 [tool.poetry.scripts]
-adopt_ruff = "adopt_ruff.adopt_ruff:main"
+adopt-ruff = "adopt_ruff.adopt_ruff:main"
 
 [tool.ruff]
 target-version = "py311"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ pydantic = "^2.5.3"
 tabulate = "^0.9.0"
 mdutils = "^1.6.0"
 loguru = "^0.7.2"
+packaging = "^23.2"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ python = "^3.11"
 pydantic = "^2.5.3"
 tabulate = "^0.9.0"
 mdutils = "^1.6.0"
+loguru = "^0.7.2"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,13 +8,13 @@ description = "Adopt Ruff faster"
 [tool.poetry.dependencies]
 python = "^3.11"
 pydantic = "^2.5.3"
-ruff = "^0.1.9"
 tabulate = "^0.9.0"
 mdutils = "^1.6.0"
 
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^3.6.0"
+ruff = "^0.1.11"
 
 [tool.poetry.scripts]
 adopt_ruff = "adopt_ruff.adopt_ruff:main"
@@ -43,6 +43,8 @@ ignore = [
     "EM101",
     "FBT001",
     "FBT002",
+    "S603",
+    "S607",
 ]
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
- Assume python, ruff are installed 
- In local repo workflow, install pip & ruff (latest)
- Add `version` input argument
- In local repo workflow, use version=`${{github.sha}}` to always run on current commit
- Move ruff parsing from workflow (bash) into the python file
- Parse ruff version in python, show it in the output