### PR TITLE
Clickable rule names

### DIFF
--- a/adopt_ruff/main.py
+++ b/adopt_ruff/main.py
@@ -95,7 +95,7 @@ def run(
             "they can be added right away 🚀"
         )
         output_table(
-            items=([r.as_dict for r in respected]),
+            items=([r.as_dict() for r in respected]),
             path=ARTIFACTS_PATH / "respected.csv",
             md=md,
             collapsible=True,
@@ -116,7 +116,7 @@ def run(
             f"{len(autofixable)} Ruff rules are violated in the repo, but can{always_status} be auto-fixed 🪄"
         )
         output_table(
-            items=([r.as_dict for r in autofixable]),
+            items=([r.as_dict() for r in autofixable]),
             path=ARTIFACTS_PATH / "autofixable.csv",
             md=md,
             collapsible=True,
@@ -150,7 +150,7 @@ def run(
         output_table(
             items=(
                 [
-                    r.as_dict | {"Violations": rule_to_violation_count[r]}
+                    r.as_dict() | {"Violations": rule_to_violation_count[r]}
                     for r in applicable_rules
                 ]
             ),

--- a/adopt_ruff/models/rule.py
+++ b/adopt_ruff/models/rule.py
@@ -38,7 +38,6 @@ class Rule(BaseModel):
     explanation: str
     preview: bool
 
-    @property
     def as_dict(self) -> dict[str, Any]:
         return {
             "Code": self.code,

--- a/adopt_ruff/utils.py
+++ b/adopt_ruff/utils.py
@@ -51,7 +51,12 @@ def output_table(
     """
     Creates a markdown table, and saves to a CSV
     """
-    md_table = tabulate(items, tablefmt="github", headers="keys")
+
+    md_table = tabulate(
+        [make_name_clickable(item) for item in items],
+        tablefmt="github",
+        headers="keys",
+    )
 
     if collapsible:
         md_table = make_collapsible(md_table, summary=collapsible_summary)
@@ -60,7 +65,13 @@ def output_table(
     table_to_csv(list(items), path)
 
 
-def search_config_file(path: Path):
+def make_name_clickable(item: dict) -> dict:
+    if not (name := item.get("Name")):
+        return item
+    return item | {"Name": f"[{name}](https://docs.astral.sh/ruff/rules/{name})"}
+
+
+def search_config_file(path: Path) -> Path | None:
     """
     Searches for common configuration files under the given directory.
     """


### PR DESCRIPTION
Make rule names clickable, leading to Ruff's documentation, e.g.

| Code     | Name                                                                                                                           | Fixable   | Preview   | Linter                     |
|----------|--------------------------------------------------------------------------------------------------------------------------------|-----------|-----------|----------------------------|
| A003     | [builtin-attribute-shadowing](https://docs.astral.sh/ruff/rules/builtin-attribute-shadowing)                                   | No        | False     | flake8-builtins            |
| AIR001   | [airflow-variable-name-task-id-mismatch](https://docs.astral.sh/ruff/rules/airflow-variable-name-task-id-mismatch)             | No        | False     | Airflow                    |
| ASYNC100 | [blocking-http-call-in-async-function](https://docs.astral.sh/ruff/rules/blocking-http-call-in-async-function)                 | No        | False     | flake8-async               |
| ASYNC101 | [open-sleep-or-subprocess-in-async-function](https://docs.astral.sh/ruff/rules/open-sleep-or-subprocess-in-async-function)     | No        | False     | flake8-async               |
