### PR TITLE
use `ruff check` when ruff version `>= 0.3.0`

### DIFF
--- a/adopt_ruff/main.py
+++ b/adopt_ruff/main.py
@@ -53,7 +53,7 @@ def run_ruff(path: Path) -> tuple[set[Rule], tuple[Violation, ...], Version]:
         for value in json.loads(
             subprocess.run(
                 [
-                    "ruff",
+                    *["ruff" if ruff_version < Version("0.3.0") else "ruff", "check"],
                     str(path),
                     "--output-format=json",
                     "--select=ALL",


### PR DESCRIPTION
The `ruff <path>` command was [deprecated in ruff 0.3.0](https://github.com/astral-sh/ruff/blob/main/CHANGELOG.md#cli-5), in favor of `ruff check <path>`.