### PR TITLE
Show category-level rules before individual rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ A tool for finding Ruff rules that are not yet configured, and can be added to y
 - Rules that can be automatically fixed by Ruff 🪄
 - Rules violated in the repository, sorted by ascending violation count 🔎
 
+**✨ New:** When all rules in a category (e.g., RUF, ASYNC) belong to the same situation, adopt-ruff highlights these categories with ready-to-use configuration snippets!
+
 The output is a markdown report, easy to check as a Github action summary and CSV files with relevant Rule information per category.
 
 _See example at the bottom of this page_
@@ -98,15 +100,28 @@ Run `adopt-ruff --help` for more information.\
 ## Respected Ruff rules
 
 374 Ruff rules are already respected in the repo - they can be added right away 🚀
+
+### ✅ Categories with ALL rules respected:
+- **flake8-async (ASYNC)**: All 12 rules 🎉
+- **flake8-builtins (A)**: All 3 rules 🎉
+
+💡 **Quick add to your config:**
+```toml
+[tool.ruff.lint]
+select = ["A", "ASYNC"]
+```
+
 <details>
 <summary>Details</summary>
 
 | Code     | Name                                         | Fixable   | Preview   | Linter                     |
 |----------|----------------------------------------------|-----------|-----------|----------------------------|
+| A001     | builtin-variable-shadowing                   | No        | False     | flake8-builtins            |
+| A002     | builtin-argument-shadowing                   | No        | False     | flake8-builtins            |
 | A003     | builtin-attribute-shadowing                  | No        | False     | flake8-builtins            |
 | AIR001   | airflow-variable-name-task-id-mismatch       | No        | False     | Airflow                    |
 | ASYNC100 | blocking-http-call-in-async-function         | No        | False     | flake8-async               |
-| ASYNC101 | open-sleep-or-subprocess-in-async-function   | No        | False     | Perflint                   |
+| ASYNC101 | open-sleep-or-subprocess-in-async-function   | No        | False     | flake8-async               |
 | PERF403  | manual-dict-comprehension                    | No        | True      | Perflint                   |
 
 (table truncated for example purposes)
@@ -116,6 +131,17 @@ Run `adopt-ruff --help` for more information.\
 ## Autofixable Ruff rules
 
 65 Ruff rules are violated in the repo, but can be auto-fixed 🪄
+
+### 🎯 Categories with ALL rules autofixable:
+- **Ruff-specific rules (RUF)**: All 5 rules ✨
+- **flake8-comprehensions (C4)**: All 8 rules ✨
+
+💡 **Quick add to your config:**
+```toml
+[tool.ruff.lint]
+select = ["C4", "RUF"]
+```
+
 <details>
 <summary>Details</summary>
 
@@ -124,6 +150,10 @@ Run `adopt-ruff --help` for more information.\
 | B010    | set-attr-with-constant                            | Always    | False     | flake8-bugbear        |
 | B011    | assert-false                                      | Always    | False     | flake8-bugbear        |
 | C401    | unnecessary-generator-set                         | Always    | False     | flake8-comprehensions |
+| C402    | unnecessary-generator-dict                        | Always    | False     | flake8-comprehensions |
+| RUF001  | ambiguous-unicode-character-string                | Always    | False     | Ruff-specific rules   |
+| RUF002  | ambiguous-unicode-character-docstring             | Always    | False     | Ruff-specific rules   |
+| RUF003  | ambiguous-unicode-character-comment               | Always    | False     | Ruff-specific rules   |
 
 (table truncated for example purposes)
 
@@ -132,6 +162,13 @@ Run `adopt-ruff --help` for more information.\
 ## Applicable Rules
 
 194 other Ruff rules are not yet configured in the repository
+
+### 📋 Categories with ALL rules violated:
+- **pydocstyle (D)**: All 58 rules 🔍
+- **flake8-use-pathlib (PTH)**: All 27 rules 🔍
+
+💡 **Tip:** These categories need attention across the entire codebase
+
 <details>
 <summary>Details</summary>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ build-backend = "hatchling.build"
 dev = [
     "mypy>=1.14.0",
     "pre-commit>=4.0.1",
+    "pytest>=8.3.4",
     "ruff>=0.8.4",
 ]
 typing = [

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Test package for adopt-ruff

--- a/tests/test_category_grouping.py
+++ b/tests/test_category_grouping.py
@@ -1,0 +1,175 @@
+"""Tests for category-level grouping functionality."""
+
+import pytest
+
+from adopt_ruff.models.rule import FixAvailability, Rule
+from adopt_ruff.utils import (
+    extract_category_prefix,
+    find_complete_categories,
+    generate_pyproject_suggestion,
+)
+
+
+class TestExtractCategoryPrefix:
+    """Tests for extract_category_prefix function."""
+
+    def test_simple_prefix(self):
+        """Test extracting simple letter prefixes."""
+        assert extract_category_prefix("B010") == "B"
+        assert extract_category_prefix("C401") == "C"
+        assert extract_category_prefix("E501") == "E"
+
+    def test_multi_letter_prefix(self):
+        """Test extracting multi-letter prefixes."""
+        assert extract_category_prefix("RUF001") == "RUF"
+        assert extract_category_prefix("ASYNC100") == "ASYNC"
+        assert extract_category_prefix("PLW0127") == "PLW"
+
+    def test_prefix_only(self):
+        """Test when code is just a prefix."""
+        assert extract_category_prefix("RUF") == "RUF"
+        assert extract_category_prefix("B") == "B"
+
+
+class TestFindCompleteCategories:
+    """Tests for find_complete_categories function."""
+
+    def create_rule(self, code: str, linter: str) -> Rule:
+        """Helper to create a test rule."""
+        return Rule(
+            name=f"test-{code}",
+            code=code,
+            linter=linter,
+            summary="Test rule",
+            message_formats=(),
+            fix=FixAvailability.ALWAYS,
+            explanation="Test explanation",
+            preview=False,
+        )
+
+    def test_complete_category(self):
+        """Test detecting a complete category."""
+        # Create all rules
+        all_rules = {
+            self.create_rule("RUF001", "Ruff-specific rules"),
+            self.create_rule("RUF002", "Ruff-specific rules"),
+            self.create_rule("RUF003", "Ruff-specific rules"),
+            self.create_rule("B010", "flake8-bugbear"),
+            self.create_rule("B011", "flake8-bugbear"),
+        }
+
+        # All RUF rules are in the situation
+        situation_rules = [
+            self.create_rule("RUF001", "Ruff-specific rules"),
+            self.create_rule("RUF002", "Ruff-specific rules"),
+            self.create_rule("RUF003", "Ruff-specific rules"),
+        ]
+
+        complete = find_complete_categories(situation_rules, all_rules)
+
+        assert "RUF" in complete
+        assert complete["RUF"] == ("Ruff-specific rules", 3)
+        assert "B" not in complete  # Not all B rules are in situation
+
+    def test_incomplete_category(self):
+        """Test when category is not complete."""
+        all_rules = {
+            self.create_rule("RUF001", "Ruff-specific rules"),
+            self.create_rule("RUF002", "Ruff-specific rules"),
+            self.create_rule("RUF003", "Ruff-specific rules"),
+        }
+
+        # Only some RUF rules are in the situation
+        situation_rules = [
+            self.create_rule("RUF001", "Ruff-specific rules"),
+            self.create_rule("RUF002", "Ruff-specific rules"),
+        ]
+
+        complete = find_complete_categories(situation_rules, all_rules)
+
+        assert "RUF" not in complete  # Not all RUF rules are in situation
+
+    def test_multiple_complete_categories(self):
+        """Test detecting multiple complete categories."""
+        all_rules = {
+            self.create_rule("RUF001", "Ruff-specific rules"),
+            self.create_rule("RUF002", "Ruff-specific rules"),
+            self.create_rule("ASYNC100", "flake8-async"),
+            self.create_rule("ASYNC101", "flake8-async"),
+            self.create_rule("B010", "flake8-bugbear"),
+        }
+
+        situation_rules = [
+            self.create_rule("RUF001", "Ruff-specific rules"),
+            self.create_rule("RUF002", "Ruff-specific rules"),
+            self.create_rule("ASYNC100", "flake8-async"),
+            self.create_rule("ASYNC101", "flake8-async"),
+        ]
+
+        complete = find_complete_categories(situation_rules, all_rules)
+
+        assert "RUF" in complete
+        assert complete["RUF"] == ("Ruff-specific rules", 2)
+        assert "ASYNC" in complete
+        assert complete["ASYNC"] == ("flake8-async", 2)
+        assert "B" not in complete
+
+    def test_empty_situation(self):
+        """Test with no rules in situation."""
+        all_rules = {
+            self.create_rule("RUF001", "Ruff-specific rules"),
+            self.create_rule("B010", "flake8-bugbear"),
+        }
+
+        complete = find_complete_categories([], all_rules)
+
+        assert len(complete) == 0
+
+    def test_single_rule_category(self):
+        """Test category with just one rule."""
+        all_rules = {
+            self.create_rule("X001", "single-rule-linter"),
+            self.create_rule("B010", "flake8-bugbear"),
+        }
+
+        situation_rules = [
+            self.create_rule("X001", "single-rule-linter"),
+        ]
+
+        complete = find_complete_categories(situation_rules, all_rules)
+
+        assert "X" in complete
+        assert complete["X"] == ("single-rule-linter", 1)
+
+
+class TestGeneratePyprojectSuggestion:
+    """Tests for generate_pyproject_suggestion function."""
+
+    def test_single_category_select(self):
+        """Test generating suggestion for a single category with select."""
+        suggestion = generate_pyproject_suggestion(["RUF"], "select")
+        assert "[tool.ruff.lint]" in suggestion
+        assert 'select = ["RUF"]' in suggestion
+        assert "```toml" in suggestion
+
+    def test_multiple_categories_select(self):
+        """Test generating suggestion for multiple categories."""
+        suggestion = generate_pyproject_suggestion(["RUF", "ASYNC", "B"], "select")
+        assert "[tool.ruff.lint]" in suggestion
+        assert 'select = ["ASYNC", "B", "RUF"]' in suggestion  # Should be sorted
+
+    def test_ignore_section(self):
+        """Test generating suggestion with ignore section."""
+        suggestion = generate_pyproject_suggestion(["RUF"], "ignore")
+        assert "[tool.ruff.lint]" in suggestion
+        assert 'ignore = ["RUF"]' in suggestion
+
+    def test_empty_categories(self):
+        """Test with empty category list."""
+        suggestion = generate_pyproject_suggestion([], "select")
+        assert suggestion == ""
+
+    def test_categories_are_sorted(self):
+        """Test that categories are sorted in output."""
+        suggestion = generate_pyproject_suggestion(["Z", "A", "M"], "select")
+        assert 'select = ["A", "M", "Z"]' in suggestion


### PR DESCRIPTION
This commit adds a new feature that highlights when all rules in a category (e.g., RUF, ASYNC) belong to the same situation (respected, autofixable, or violated).

Key changes:
- Added category detection logic to identify complete categories
- Display category summaries with emojis before detailed tables
- Generate ready-to-use pyproject.toml configuration snippets
- All rules still appear in detailed tables and CSV exports
- Added comprehensive test suite for new functionality
- Updated README with examples and feature documentation

The feature helps users quickly adopt entire rule categories by providing copy-paste configuration snippets.